### PR TITLE
Expose deployment_id as workflow output

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ As seen above, we have two steps. One for a noop deploy, and one for a regular d
 | noop | The string "true" if the noop trigger was found, otherwise the string "false" - Use this to conditionally control whether your deployment runs as a noop or not |
 | ref | The ref (branch or sha) to use with deployment |
 | comment_id | The comment id which triggered this deployment |
+| deployment_id | The ID of the deployment created by running this action |
 | type | The type of trigger that was detected (examples: deploy, lock, unlock) |
 | continue | The string "true" if the deployment should continue, otherwise empty - Use this to conditionally control if your deployment should proceed or not - ⭐ The main output you should watch for when determining if a deployment shall carry on |
 | fork | The string "true" if the pull request is a fork, otherwise "false" |

--- a/src/main.js
+++ b/src/main.js
@@ -366,6 +366,7 @@ export async function run() {
       ref: precheckResults.ref,
       required_contexts: requiredContexts
     })
+    core.saveOutput('deployment_id', createDeploy.id)
     core.saveState('deployment_id', createDeploy.id)
 
     // If a merge to the base branch is required, let the user know and exit


### PR DESCRIPTION
This commit exposes the deployment_id as output of this workflow so that
jobs that follow up this one, can use it for their own purposes.
