### PR TITLE
update unlock-on-merge docs

### DIFF
--- a/docs/unlock-on-merge.md
+++ b/docs/unlock-on-merge.md
@@ -25,6 +25,9 @@ permissions:
 jobs:
   unlock-on-merge:
     runs-on: ubuntu-latest
+    # Gate this job to only run when the pull request is merged (not closed)
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
+    if: github.event.pull_request.merged == true
 
     steps:
       - name: unlock on merge


### PR DESCRIPTION
This pull request updates the `unlock-on-merge` workflow strategy docs.

Users should include `if: github.event.pull_request.merged == true` as reflected in the updated docs to prevent this alternate workflow strategy from failing if the workflow run executes on a PR "closed" event