### PR TITLE
Add multi-environment example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -50,12 +50,11 @@ jobs:
     if: ${{ github.event.issue.pull_request }} # only run on pull request comments
 
     steps:
-
-        # The branch-deploy Action
+      # The branch-deploy Action
       - name: branch-deploy
         id: branch-deploy
         uses: github/branch-deploy@vX.X.X
-        
+
         # If the branch-deploy Action was triggered, checkout our branch
       - uses: actions/checkout@v3
         with:
@@ -83,7 +82,7 @@ name: branch-deploy
 
 on:
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 # The working directory where our Terraform files are located
 env:
@@ -93,7 +92,7 @@ env:
 permissions:
   pull-requests: write
   deployments: write
-  contents: write 
+  contents: write
   checks: read
 
 jobs:
@@ -107,8 +106,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }} # the directory we use where all our TF files are stored
 
     steps:
-
-        # The branch-deploy Action
+      # The branch-deploy Action
       - name: branch-deploy
         id: branch-deploy
         uses: github/branch-deploy@vX.X.X
@@ -189,7 +187,7 @@ name: branch-deploy
 
 on:
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 permissions:
   pull-requests: write
@@ -205,8 +203,7 @@ jobs:
     environment: production-secrets # the locked down environment we pull secrets from
 
     steps:
-
-        # The branch-deploy Action
+      # The branch-deploy Action
       - name: branch-deploy
         id: branch-deploy
         uses: github/branch-deploy@vX.X.X
@@ -242,7 +239,7 @@ name: branch-deploy
 
 on:
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 permissions:
   pull-requests: write
@@ -258,8 +255,7 @@ jobs:
     environment: production-secrets # the locked down environment we pull secrets from
 
     steps:
-
-        # The branch-deploy Action
+      # The branch-deploy Action
       - name: branch-deploy
         id: branch-deploy
         uses: github/branch-deploy@vX.X.X
@@ -305,7 +301,7 @@ on:
 permissions:
   pull-requests: write
   deployments: write
-  contents: write 
+  contents: write
   checks: read
 
 jobs:
@@ -315,8 +311,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
-        # The branch-deploy Action
+      # The branch-deploy Action
       - uses: github/branch-deploy@vX.X.X
         id: branch-deploy
 
@@ -354,7 +349,7 @@ name: branch-deploy
 
 on:
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 # Permissions needed for reacting and adding comments for IssueOps commands
 permissions:
@@ -370,8 +365,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
-        # The branch-deploy Action
+      # The branch-deploy Action
       - uses: github/branch-deploy@vX.X.X
         id: branch-deploy
 
@@ -427,7 +421,7 @@ name: branch-deploy
 
 on:
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 # Permissions needed for reacting and adding comments for IssueOps commands
 permissions:
@@ -443,8 +437,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
-        # The branch-deploy Action
+      # The branch-deploy Action
       - uses: github/branch-deploy@vX.X.X
         id: branch-deploy
 
@@ -469,7 +462,7 @@ jobs:
         uses: cloudflare/wrangler-action@3424d15af26edad39d5276be3cc0cc9ffec22b55 # pin@1.3.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
-          environment: "development" # here we use development
+          environment: 'development' # here we use development
 
         # If '.deploy' was used, branch deploy to the production environment
       - name: Publish - Production
@@ -603,7 +596,7 @@ jobs:
         uses: GrantBirki/comment@1e9986de26cf23e6c4350276234c91705c540fef # pin@v2.0.3
         with:
           comment-id: ${{ needs.trigger.outputs.comment_id }}
-          reactions: "-1"
+          reactions: '-1'
 
       # if the deployment was successful, add a 'success' comment
       - name: success comment
@@ -640,7 +633,7 @@ name: branch deploy
 # The workflow to execute on is comments that are newly created
 on:
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 # Permissions needed for reacting and adding comments for IssueOps commands
 permissions:
@@ -680,11 +673,11 @@ jobs:
       - uses: github/branch-deploy@vX.X.X
         id: branch-deploy
         with:
-          trigger: ".deploy"
-          environment: "github-pages"
-          production_environment: "github-pages"
-          skip_completing: "true" # we will complete the deployment manually in the 'result' job
-          admins: "false" # <--- add your GitHub username here (if you want to use the admins feature)
+          trigger: '.deploy'
+          environment: 'github-pages'
+          production_environment: 'github-pages'
+          skip_completing: 'true' # we will complete the deployment manually in the 'result' job
+          admins: 'false' # <--- add your GitHub username here (if you want to use the admins feature)
 
   # build the github-pages site with hugo
   build:
@@ -737,7 +730,7 @@ jobs:
 
   # deploy to GitHub Pages
   deploy:
-    needs: [ trigger, build ]
+    needs: [trigger, build]
     if: ${{ needs.trigger.outputs.continue == 'true' }} # only run if the trigger job set continue to true
     environment:
       name: github-pages
@@ -752,7 +745,7 @@ jobs:
 
   # update the deployment result - manually complete the deployment that was created by the branch-deploy action
   result:
-    needs: [ trigger, build, deploy ]
+    needs: [trigger, build, deploy]
     runs-on: ubuntu-latest
     # run even on failures but only if the trigger job set continue to true
     if: ${{ always() && needs.trigger.outputs.continue == 'true' }}
@@ -761,7 +754,8 @@ jobs:
       # if a previous step failed, set a variable to use as the deployment status
       - name: set deployment status
         id: deploy-status
-        if: ${{ needs.trigger.result == 'failure' || needs.build.result == 'failure' ||
+        if:
+          ${{ needs.trigger.result == 'failure' || needs.build.result == 'failure' ||
           needs.deploy.result == 'failure' }}
         run: |
           echo "DEPLOY_STATUS=failure" >> $GITHUB_OUTPUT
@@ -818,7 +812,7 @@ jobs:
         uses: GrantBirki/comment@1e9986de26cf23e6c4350276234c91705c540fef # pin@v2.0.3
         with:
           comment-id: ${{ needs.trigger.outputs.comment_id }}
-          reactions: "-1"
+          reactions: '-1'
 
       # if the deployment was successful, add a 'success' comment
       - name: success comment
@@ -857,7 +851,7 @@ name: branch deploy
 # The workflow to execute on is comments that are newly created
 on:
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 # Permissions needed for reacting and adding comments for IssueOps commands
 permissions:
@@ -897,12 +891,12 @@ jobs:
       - uses: github/branch-deploy@vX.X.X
         id: branch-deploy
         with:
-          trigger: ".deploy"
-          environment: "github-pages"
-          production_environment: "github-pages"
-          environment_targets: "github-pages"
-          skip_completing: "true" # we will complete the deployment manually in the 'result' job
-          admins: "false" # <--- add your GitHub username here (if you want to use the admins feature)
+          trigger: '.deploy'
+          environment: 'github-pages'
+          production_environment: 'github-pages'
+          environment_targets: 'github-pages'
+          skip_completing: 'true' # we will complete the deployment manually in the 'result' job
+          admins: 'false' # <--- add your GitHub username here (if you want to use the admins feature)
 
   # build the github-pages site with hugo
   build:
@@ -921,7 +915,7 @@ jobs:
 
   # deploy to GitHub Pages
   deploy:
-    needs: [ trigger, build ]
+    needs: [trigger, build]
     if: ${{ needs.trigger.outputs.continue == 'true' }} # only run if the trigger job set continue to true
     environment:
       name: github-pages
@@ -936,7 +930,7 @@ jobs:
 
   # update the deployment result - manually complete the deployment that was created by the branch-deploy action
   result:
-    needs: [ trigger, build, deploy ]
+    needs: [trigger, build, deploy]
     runs-on: ubuntu-latest
     # run even on failures but only if the trigger job set continue to true
     if: ${{ always() && needs.trigger.outputs.continue == 'true' }}
@@ -945,7 +939,8 @@ jobs:
       # if a previous step failed, set a variable to use as the deployment status
       - name: set deployment status
         id: deploy-status
-        if: ${{ needs.trigger.result == 'failure' || needs.build.result == 'failure' ||
+        if:
+          ${{ needs.trigger.result == 'failure' || needs.build.result == 'failure' ||
           needs.deploy.result == 'failure' }}
         run: |
           echo "DEPLOY_STATUS=failure" >> $GITHUB_OUTPUT
@@ -966,7 +961,7 @@ jobs:
             repos/{owner}/{repo}/deployments/${{ needs.trigger.outputs.deployment_id }}/statuses \
             -f environment='${{ needs.trigger.outputs.environment }}' \
             -f state=${DEPLOY_STATUS}
-      
+
       # use the GitHub CLI to remove the non-sticky lock that was created by the branch-deploy action
       - name: Remove a non-sticky lock
         env:
@@ -1002,7 +997,7 @@ jobs:
         uses: GrantBirki/comment@1e9986de26cf23e6c4350276234c91705c540fef # pin@v2.0.3
         with:
           comment-id: ${{ needs.trigger.outputs.comment_id }}
-          reactions: "-1"
+          reactions: '-1'
 
       # if the deployment was successful, add a 'success' comment
       - name: success comment

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -20,6 +20,7 @@ Quick links below to jump to a specific branch-deploy example:
   - [Multiple Jobs](#multiple-jobs)
   - [Multiple Jobs with GitHub Pages and Hugo](#multiple-jobs-with-github-pages-and-hugo)
   - [Multiple Jobs with GitHub Pages and Astro](#multiple-jobs-with-github-pages-and-astro)
+  - [Multiple Jobs with GitHub Environments](#multiple-jobs-with-github-environments)
 
 ## Simple Example
 
@@ -1026,6 +1027,298 @@ jobs:
             ### Deployment Results ❌
 
             **${{ needs.trigger.outputs.actor_handle }}** had a failure when deploying `${{ needs.trigger.outputs.ref }}` to **${{ needs.trigger.outputs.environment }}**
+```
+
+## Multiple Jobs with GitHub Environments
+
+A detailed example using multiple jobs, [repository environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment), and Terraform. As mentioned in the [README](https://github.com/github/branch-deploy#about-environments-), a deployment completes when the workflow targeting that environment completes. In this example, the branch deployment action targets a separate environment than the "actual" deployment logic, which lets us control the completion of the branch deployment while being able to manage environments separately.
+
+```yaml
+name: Branch Deploy
+
+on:
+  issue_comment:
+    types:
+      - created
+
+env:
+  # These variables are scoped to the **repository**.
+  TF_VAR_image_repository: ${{ vars.IMAGE_REPOSITORY }}
+
+permissions:
+  checks: read
+  contents: write
+  deployments: write
+  packages: read
+  pull-requests: write
+
+jobs:
+  start:
+    name: Start Branch Deployment
+    runs-on: ubuntu-latest
+
+    # Only start branch deployments on pull request comments.
+    if: ${{ github.event.issue.pull_request }}
+
+    # The deployments environment is used by the branch-deploy workflow.
+    environment: deployments
+
+    # Set the outputs to be used by the rest of the workflow.
+    outputs:
+      continue: ${{ steps.branch-deploy.outputs.continue }}
+      noop: ${{ steps.branch-deploy.outputs.noop }}
+      deployment_id: ${{ steps.branch-deploy.outputs.deployment_id }}
+      environment: ${{ steps.branch-deploy.outputs.environment }}
+      ref: ${{ steps.branch-deploy.outputs.ref }}
+      comment_id: ${{ steps.branch-deploy.outputs.comment_id }}
+      initial_reaction_id: ${{ steps.branch-deploy.outputs.initial_reaction_id }}
+      actor_handle: ${{ steps.branch-deploy.outputs.actor_handle }}
+
+    steps:
+      - name: Start Branch Deployment
+        id: branch-deploy
+        uses: github/branch-deploy@v7.3.1
+        with:
+          environment: development
+          environment_targets: development,staging,production
+          skip_completing: true
+
+  # This is the "actual" deployment logic. It uses the environment specified in
+  # the branch deployment comment (e.g. `.deploy to development`).
+  deploy:
+    needs: start
+
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    # Only start after the branch deployment has initialized.
+    if: ${{ needs.start.outputs.continue == 'true' }}
+
+    # Use the environment specified by the `.noop` or `.deploy` comment.
+    environment: ${{ needs.start.outputs.environment }}
+
+    # Set the default working directory to `tf/` (or wherever your Terraform
+    # code is located in your repository).
+    defaults:
+      run:
+        working-directory: tf/
+
+    # Set the deployment outcome based on if `terraform plan` (.noop) or
+    # `terraform apply` (.deploy) succeeded. Defaults to 'failure'.
+    outputs:
+      outcome: ${{ (steps.plan.outcome == 'success' || steps.apply.outcome == 'success') && 'success' || 'failure' }}
+
+    # These variables/secrets are scoped to the **environment**.
+    env:
+      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      TF_VAR_location: ${{ vars.AZURE_LOCATION }}
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.start.outputs.ref }}
+
+      # Authenticate to Azure using OpenID Connect.
+      - name: Authenticate to Azure (OIDC)
+        id: azure-oidc
+        uses: azure/login@v1
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tenant-id: ${{ env.ARM_TENANT_ID }}
+
+      # Install Terraform on the runner.
+      - name: Setup Terraform
+        id: setup-terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.5
+
+      # This example uses separate Terraform workspaces for each environment.
+      - name: Terraform Init
+        id: terraform-init
+        run: |
+          terraform init -no-color
+          terraform workspace select -or-create=true ${{ needs.start.outputs.environment }}
+
+      # If this is a `.noop`, run `terraform plan` to see what would change.
+      - name: Terraform Plan
+        id: plan
+        if: ${{ needs.start.outputs.noop == 'true' }}
+        run: terraform plan -no-color
+        continue-on-error: true
+
+      # If this is a `.deploy`, run `terraform apply` to apply the changes.
+      - name: Terraform Apply
+        id: apply
+        if: ${{ needs.start.outputs.noop != 'true' }}
+        run: terraform apply -no-color -auto-approve
+        continue-on-error: true
+
+      # Get the output from the plan/apply step.
+      - name: Save Terraform Output
+        id: output
+        env:
+          PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
+          APPLY_STDOUT: ${{ steps.apply.outputs.stdout }}
+        run: |
+          if [ -z "$PLAN_STDOUT" ]
+          then
+            echo "$APPLY_STDOUT" > tf_output.txt
+          else
+            echo "$PLAN_STDOUT" > tf_output.txt
+          fi
+
+      # Upload the plan/apply output as an artifact so that it can be used in
+      # the `stop` job.
+      - name: Upload Terraform Output
+        id: upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: tf_output
+          path: tf/tf_output.txt
+
+  stop:
+    needs:
+      - start
+      - deploy
+
+    name: Stop Branch Deployment
+    runs-on: ubuntu-latest
+
+    # Always run this job if the branch deployment was started.
+    if: ${{ always() && needs.start.outputs.continue == 'true' }}
+
+    # Switch back to the deployments environment to update the branch
+    # deployment status.
+    environment: deployments
+
+    # Get the outputs from the `start` job. These are needed to finish the
+    # branch deployment, comment on the PR, update reactions, etc.
+    env:
+      ACTOR: ${{ needs.start.outputs.actor_handle }}
+      COMMENT_ID: ${{ needs.start.outputs.comment_id }}
+      DEPLOYMENT_ID: ${{ needs.start.outputs.deployment_id }}
+      DEPLOYMENT_STATUS: ${{ needs.deploy.outputs.outcome || 'failure' }}
+      ENVIRONMENT: ${{ needs.start.outputs.environment }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      INITIAL_REACTION_ID: ${{ needs.start.outputs.initial_reaction_id }}
+      NOOP: ${{ needs.start.outputs.noop }}
+      REF: ${{ needs.start.outputs.ref }}
+      REPOSITORY: ${{ github.repository }}
+
+    steps:
+      # Tf this was not a `.noop` deployment, set the status.
+      - if: ${{ env.NOOP != 'true' }}
+        name: Set Deployment Status
+        id: set-status
+        run: |
+          gh api --method POST \
+            "repos/${{ env.REPOSITORY }}/deployments/${{ env.DEPLOYMENT_ID }}/statuses" \
+            -f environment="${{ env.ENVIRONMENT }}" \
+            -f state="${{ env.DEPLOYMENT_STATUS }}"
+
+      # If this was not a `.noop` deployment, remove the lock.
+      - if: ${{ env.NOOP != 'true' }}
+        name: Remove Non-Sticky Lock
+        id: remove-lock
+        run: |
+          gh api --method DELETE \
+            "repos/${{ env.REPOSITORY }}/git/refs/heads/${{ env.ENVIRONMENT }}-branch-deploy-lock"
+
+      # Remove the trigger reaction added to the user's comment.
+      - name: Remove Trigger Reaction
+        id: remove-reaction
+        run: |
+          gh api --method DELETE \
+            "repos/${{ env.REPOSITORY }}/issues/comments/${{ env.COMMENT_ID }}/reactions/${{ env.INITIAL_REACTION_ID }}"
+
+      # Add a new reaction based on if the deployment succeeded or failed.
+      - name: Add Reaction
+        id: add-reaction
+        uses: GrantBirki/comment@v2.0.6
+        env:
+          REACTION: ${{ env.DEPLOYMENT_STATUS == 'success' && 'rocket' || '-1' }}
+        with:
+          comment-id: ${{ env.COMMENT_ID }}
+          reactions: ${{ env.DEPLOYMENT_STATUS == 'success' && 'rocket' || '-1' }}
+
+      # If the plan/apply didn't run because of a failure, this step will also
+      # fail, hence setting continue-on-error.
+      - name: Get Terraform Output Artifact
+        id: get-artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: tf_output
+        continue-on-error: true
+
+      # Add a success comment, including the plan/apply output (if present).
+      - if: ${{ env.DEPLOYMENT_STATUS == 'success' }}
+        name: Add Success Comment
+        id: success-comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs')
+
+            let output
+            try { output = fs.readFileSync('tf_output.txt', 'utf8') }
+            catch (err) { output = 'No Terraform output!' }
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### Deployment Results :white_check_mark:
+
+            **${{ env.ACTOR }}** successfully ${ process.env.NOOP === 'true' ? '**noop** deployed' : 'deployed' } branch \`${{ env.REF }}\` to **${{ env.ENVIRONMENT }}**
+
+            <details><summary>Show Results</summary>
+
+            \`\`\`terraform\n${ output }\n\`\`\`
+
+            </details>`
+            })
+
+      # Add a failure comment, including the plan/apply output (if present).
+      - if: ${{ env.DEPLOYMENT_STATUS == 'failure' }}
+        name: Add Failure Comment
+        id: failure-comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs')
+
+            let output
+            try { output = fs.readFileSync('tf_output.txt', 'utf8') }
+            catch (err) { output = 'No Terraform output!' }
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### Deployment Results :x:
+
+            **${{ env.ACTOR }}** had a failure when ${ process.env.NOOP === 'true' ? '**noop** deploying' : 'deploying' } branch \`${{ env.REF }}\` to **${{ env.ENVIRONMENT }}**
+
+            <details><summary>Show Results</summary>
+
+            \`\`\`terraform\n${ output }\n\`\`\`
+
+            </details>`
+            })
+
+      # If the deployment failed, fail the workflow.
+      - if: ${{ env.DEPLOYMENT_STATUS == 'failure' }}
+        name: Fail Workflow
+        id: fail-workflow
+        run: |
+          echo "There was a deployment problem...failing the workflow!"
+          exit 1
 ```
 
 ---


### PR DESCRIPTION
👋🏻 This PR adds a new multi-job example that shows how separate environments can be used to start/stop the branch-deploy process and perform the actual deployment.

The original need that resulted in this approach was being able to deploy to multiple Azure environments using Terraform. In particular, each environment was located on a separate tenant/subscription, hence the need for different credentials, Terraform workspaces, etc. Originally, I tried writing this to use only a `secrets` environment as mentioned in the [README](https://github.com/github/branch-deploy#about-environments-), but the workflow ended up with a lot of additional fluff to simply choose the right secrets/variables. I left in a fair bit of detail, so please feel free to remove anything that might be extraneous.

_Also:_ Prettier automatically formatted some of the other examples. I did confirm that nothing was changed functionally.

I'd be happy to hear any feedback!