### PR TITLE
Add read access to statuses to required permissions

### DIFF
--- a/.github/workflows/old/sample-workflow.yml
+++ b/.github/workflows/old/sample-workflow.yml
@@ -9,6 +9,7 @@
 #   deployments: write
 #   contents: write
 #   checks: read
+#   statuses: read
 
 # jobs:
 #   sample:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 jobs:
   demo:
@@ -189,6 +190,7 @@ permissions:
   deployments: write # Required for updating deployment statuses
   contents: write # Required for reading/writing the lock file
   checks: read # Required for checking if the CI checks have passed in order to deploy the PR
+  statuses: read # Required for checking if all commit statuses are "success" in order to deploy the PR
 ```
 
 These are the minimum permissions you need to run this Action
@@ -455,6 +457,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 ```
 
 Permissions Explained:
@@ -463,6 +466,7 @@ Permissions Explained:
 - `deployments`: `write` - Required to update repository deployment statuses
 - `contents`: `write` - Write access is required for this Action to create "lock" branches for deployments
 - `checks`: `read` - Only read access is needed for this Action to get the status of other CI checks
+- `statuses`: `read` - Only read access is needed for this Action to get the commit statuses of commits in the PR
 
 It should also be noted that this Action has built in functions to check the permissions of a user who invokes a IssueOps command. If the user does not have `write` or greater permissions to the repository, their command will be rejected
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -42,6 +42,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 jobs:
   deploy:
@@ -99,6 +100,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 jobs:
   deploy:
@@ -200,6 +202,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 jobs:
   deploy:
@@ -252,6 +255,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 jobs:
   deploy:
@@ -282,7 +286,7 @@ jobs:
         if: steps.branch-deploy.outputs.continue == 'true'
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: railway up  
+        run: railway up
 ```
 
 ## SSH
@@ -309,6 +313,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 jobs:
   deploy:
@@ -363,6 +368,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 jobs:
   deploy:
@@ -444,6 +450,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 jobs:
   deploy:
@@ -509,6 +516,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 jobs:
   trigger:
@@ -592,7 +600,7 @@ jobs:
             --jq '.content' \
             | base64 --decode \
             > lock.json
-          
+
           # Check if the sticky value is true
           if [ "$(jq -r '.sticky' lock.json)" = "true" ]; then
             echo "The lock is sticky, skipping the delete step"
@@ -676,6 +684,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 # set an environment variable for use in the jobs pointing to my blog
 env:
@@ -825,7 +834,7 @@ jobs:
             --jq '.content' \
             | base64 --decode \
             > lock.json
-          
+
           # Check if the sticky value is true
           if [ "$(jq -r '.sticky' lock.json)" = "true" ]; then
             echo "The lock is sticky, skipping the delete step"
@@ -911,6 +920,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
   pages: write
   id-token: write
 
@@ -1029,7 +1039,7 @@ jobs:
             --jq '.content' \
             | base64 --decode \
             > lock.json
-          
+
           # Check if the sticky value is true
           if [ "$(jq -r '.sticky' lock.json)" = "true" ]; then
             echo "The lock is sticky, skipping the delete step"
@@ -1113,6 +1123,7 @@ env:
 
 permissions:
   checks: read
+  statuses: read
   contents: write
   deployments: write
   packages: read


### PR DESCRIPTION
Required for https://github.com/github/branch-deploy/blob/1f6516ef5092890ce75d9e97ca7cbdb628e38bdd/src/functions/prechecks.js#L120.

(This is only required if any integrations are setting commit statuses, and since most integrations use checks you can usually get away without it. Vercel is a notable exception, and it does very little harm to ask for this permission in all cases.)