### PR TITLE
Docs updates about `.noop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This Action does the heavy lifting for you to enable branch deployments:
 ## Available Commands 💬
 
 - `.deploy` - Deploy a pull request
-- `.noop` - Deploy a pull request in noop mode
+- `.noop` - Deploy a pull request in noop mode. Noop deployments do not require a PR review or approval
 - `.deploy to <environment>` - Deploy a pull request to a specific environment
 - `.deploy <stable_branch>` - Trigger a rollback deploy to your stable branch (main, master, etc)
 - `.lock` - Create a deployment lock for the default environment
@@ -157,7 +157,7 @@ Branch deployments are a battle tested way of deploying your changes to a given 
 - The `main` branch is always considered to be a stable and deployable branch
 - All changes are deployed to production before they are merged to the `main` branch
 - To roll back a branch deployment, you deploy the `main` branch
-- `noop` deployments should not make changes but rather report what they "would" have done
+- `noop` deployments should not make changes but rather report what they "would" have done and do not require approval or review before starting
 
 #### Why use branch deployments?
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,6 +21,9 @@ Deployments respect your repository's branch protection settings. You can trigge
 - `.deploy <stable_branch>` - Trigger a rollback deploy to your stable branch (main, master, etc)
 - `.noop <stable_branch>` - Trigger a rollback noop to your stable branch (main, master, etc)
 
+> [!NOTE]
+> `.noop` does not require a PR approval or review in order to be executed. It is intended to be run before an approval or PR review is completed in most use cases.
+
 ## Deployment Locks 🔒
 
 If you need to lock deployments so that only you can trigger them, you can use the following set of commands:


### PR DESCRIPTION
Adding a couple breadcrumbs about `.noop` and approval/review of PRs in the readme and usage.md docs.