### PR TITLE
Workflow Updates

### DIFF
--- a/.github/workflows/actions-config-validation.yml
+++ b/.github/workflows/actions-config-validation.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: actions-config-validation
         uses: GrantBirki/json-yaml-validate@e42e6ece9b97f2b220274c909a9a98e380c2c9fd # pin@v3.2.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/update-latest-release-tag.yml
+++ b/.github/workflows/update-latest-release-tag.yml
@@ -31,7 +31,12 @@ jobs:
           git config user.email github-actions@github.com
 
       - name: tag new target
-        run: git tag -f ${{ github.event.inputs.major_version_tag }} ${{ github.event.inputs.source_tag }}
+        env:
+          SOURCE_TAG: ${{ github.event.inputs.source_tag }}
+          MAJOR_VERSION_TAG: ${{ github.event.inputs.major_version_tag }}
+        run: git tag -f ${MAJOR_VERSION_TAG} ${SOURCE_TAG}
 
       - name: push new tag
-        run: git push origin ${{ github.event.inputs.major_version_tag }} --force
+        env:
+          MAJOR_VERSION_TAG: ${{ github.event.inputs.major_version_tag }}
+        run: git push origin ${MAJOR_VERSION_TAG} --force

--- a/.github/workflows/update-latest-release-tag.yml
+++ b/.github/workflows/update-latest-release-tag.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: git config
         run: |


### PR DESCRIPTION
This pull request does the following:

- sets `persist-credentials` to `false` for all calls to `actions/checkout`
- uses env vars over template variables in the "Update Latest Release Tag" workflow