### PR TITLE
docs(readme): add .noop <target> usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This Action does the heavy lifting for you to enable branch deployments:
 - `.deploy` - Deploy a pull request
 - `.noop` - Deploy a pull request in noop mode. Noop deployments do not require a PR review or approval
 - `.deploy to <environment>` - Deploy a pull request to a specific environment
+- `.noop to <environment>` - Deploy a pull request in noop mode to a specific environment
 - `.deploy <stable_branch>` - Trigger a rollback deploy to your stable branch (main, master, etc)
+- `.noop <stable_branch>` - Trigger a rollback deploy in noop mode to your stable branch (main, master, etc)
 - `.lock` - Create a deployment lock for the default environment
 - `.lock --reason <text>` - Create a deployment lock for the default environment with a custom reason
 - `.lock --details` - View details about a deployment lock


### PR DESCRIPTION
## Summary

Hi😀 Thank you for creating such a great action - branch-deploy is an amazing action!

This pull request improves the top section of the `README.md` to make it clearer that the `.noop` command also accepts `<environment>` and `<stable_branch>` as arguments.

## Motivation

Currently, the [Available Commands 💬](https://github.com/github/branch-deploy?tab=readme-ov-file#available-commands-) section at the top of `README.md` lists only `.noop`, without showing that it can take arguments. This might cause confusion for first-time users, who may assume that `.noop` does not support arguments.

Even though this is explained other documentation 🎉

- In the [Environment Targets](https://github.com/github/branch-deploy?tab=readme-ov-file#environment-targets) section of `README.md`
- And in the [Deployment 🚀](https://github.com/github/branch-deploy/blob/main/docs/usage.md#deployment-) section of `usage.md`

Thanks again!