### PR TITLE
add dependency cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: "/"
+    cooldown:
+      default-days: 45
     groups:
       github-actions:
         patterns:
@@ -11,6 +13,8 @@ updates:
       interval: monthly
   - package-ecosystem: npm
     directory: "/"
+    cooldown:
+      default-days: 90
     groups:
       npm-dependencies:
         patterns:


### PR DESCRIPTION
The `npm` ecosystem recently has been getting hit with supply chain attacks quite badly. This PR makes it so we have a bit of a cooldown with Actions + npm packages so we don't upgrade to them _right away_ when changes come out.

cc: @nobe4 