### PR TITLE
Clarify empty reaction output

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ As seen above, we have two steps. One for a noop deploy, and one for a regular d
 | `fork_label` | The API label field returned for the fork |
 | `fork_checkout` | The console command presented in the GitHub UI to checkout a given fork locally |
 | `fork_full_name` | The full name of the fork in "org/repo" format |
-| `initial_reaction_id` | The reaction id for the initial reaction on the trigger comment. This is empty when decorative reactions are disabled. |
+| `initial_reaction_id` | The reaction id for the initial reaction on the trigger comment. This can be empty when decorative reactions are disabled or the best-effort reaction request fails. |
 | `initial_comment_id` | The comment id for the "Deployment Triggered 🚀" comment created by the action |
 | `actor_handle` | The handle of the user who triggered the action |
 | `global_lock_claimed` | The string "true" if the global lock was claimed |

--- a/action.yml
+++ b/action.yml
@@ -251,7 +251,7 @@ outputs:
   environment_url:
     description: The environment URL detected and used for the deployment (sourced from the environment_urls input)
   initial_reaction_id:
-    description: The reaction id for the initial reaction on the trigger comment
+    description: The reaction id for the initial reaction on the trigger comment. This can be empty when decorative reactions are disabled or the best-effort reaction request fails
   initial_comment_id:
     description: The comment id for the "Deployment Triggered 🚀" comment created by the action
   actor_handle:


### PR DESCRIPTION
Clarify that `initial_reaction_id` can be empty when decorative reactions are disabled or their best-effort request fails.
