### PR TITLE
route npm package pulls through the public cfs proxy

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   acceptance:
     runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_REGISTRY: ${{ vars.CFS_NPM_REGISTRY || 'https://packagefeedproxy.microsoft.io/npm/' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,6 +6,8 @@ on: workflow_dispatch
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_REGISTRY: ${{ vars.CFS_NPM_REGISTRY || 'https://packagefeedproxy.microsoft.io/npm/' }}
     # Set the permissions to the lowest permissions possible needed for *your steps*. Copilot will be given its own token for its operations.
     permissions:
       # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_REGISTRY: ${{ vars.CFS_NPM_REGISTRY || 'https://packagefeedproxy.microsoft.io/npm/' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   package-check:
     runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_REGISTRY: ${{ vars.CFS_NPM_REGISTRY || 'https://packagefeedproxy.microsoft.io/npm/' }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       contents: write
       id-token: write
     env:
+      NPM_CONFIG_REGISTRY: ${{ vars.CFS_NPM_REGISTRY || 'https://packagefeedproxy.microsoft.io/npm/' }}
       ATTESTED_FILES: |-
         action.yml
         dist/index.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_REGISTRY: ${{ vars.CFS_NPM_REGISTRY || 'https://packagefeedproxy.microsoft.io/npm/' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+registry=https://packagefeedproxy.microsoft.io/npm/
 min-release-age=10


### PR DESCRIPTION
Repository package restores now use the public CFS npm proxy while Actions retain a centrally managed registry override with a safe public fallback.

## What

- Default local npm restores to the public CFS proxy.
- Configure every repository Actions npm install job with `vars.CFS_NPM_REGISTRY` and the public fallback.
- Keep Dependabot configuration, lockfile URLs, and the committed action bundle unchanged.

## Why

Centralizing package pulls gives the repository a consistent CFS route without rewriting lockfile tarball hosts or enabling the incompatible `NPM_CONFIG_REPLACE_REGISTRY_HOST=always` setting.

## Validation

- Locked `npm ci --ignore-scripts --no-audit --no-fund` completed through the public CFS proxy and left `package-lock.json` unchanged.
- `npm run format-check`, both TypeScript checks, the policy lint, YAML parsing, and `npm run package` passed; the bundle reproduced exactly.
- The native test wrapper is deferred to CI because this workspace has Node 25.8.2 while the repository requires Node 24.18.0.
